### PR TITLE
[Feat] 네이버 상품 요소 수정, 관련 경로 연결

### DIFF
--- a/src/api/naver.js
+++ b/src/api/naver.js
@@ -11,7 +11,7 @@ const api = axios.create({
   },
 });
 
-export const fetchShoppingData = async ({ query = "옷", page = 1, display = 12 }) => {
+export const fetchShoppingData = async ({ query, page = 1, display = 12 }) => {
   const start = (page - 1) * display + 1;
 
   const response = await api.get("/search/shop.json", {

--- a/src/components/product/ProductPreviewCard.jsx
+++ b/src/components/product/ProductPreviewCard.jsx
@@ -95,22 +95,27 @@ const ProductWishBtn = styled.button`
   justify-content: center;
 `;
 
-const ProductPreviewCard = ({ key, image, title, hprice, lprice }) => {
-    const navigate = useNavigate();
-  
-    return (
-      <CardContainer>
-        <ProductImage imageUrl={image} />
-        <ProductName dangerouslySetInnerHTML={{ __html: title }} />
-        <BottomContainer>
-          <ProductInfoContainer>
-            <ProductHighPrice>최고가 :{hprice}</ProductHighPrice>
-            <ProductLowPrice>최저가 : {lprice}</ProductLowPrice>
-          </ProductInfoContainer>
-          <ProductWishBtn>담기</ProductWishBtn>
-        </BottomContainer>
-      </CardContainer>
-    );
+const ProductPreviewCard = ({ item }) => {
+  const navigate = useNavigate();
+
+  const handleAddWishExistClick = (e) => {
+    e.stopPropagation(); 
+    navigate("/wish/add/exist", { state: { product: item } }); 
   };
+
+  return (
+    <CardContainer>
+      <ProductImage imageUrl={item.image} />
+      <ProductName dangerouslySetInnerHTML={{ __html: item.title }} />
+      <BottomContainer>
+        <ProductInfoContainer>
+          <ProductHighPrice>브랜드 : {item.brand}</ProductHighPrice>
+          <ProductLowPrice>가격 : {item.lprice} 원</ProductLowPrice>
+        </ProductInfoContainer>
+        <ProductWishBtn onClick={handleAddWishExistClick}>담기</ProductWishBtn>
+      </BottomContainer>
+    </CardContainer>
+  );
+};
   
-  export default ProductPreviewCard;
+export default ProductPreviewCard;

--- a/src/pages/product/ProductDetailPage.jsx
+++ b/src/pages/product/ProductDetailPage.jsx
@@ -1,21 +1,22 @@
 import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import addImageURL from "../../assets/productAdd.svg";
-import ProductImageUrl from "./../../images/wishProduct.png"    // 임시 사진
 import Colors from "../../constanst/color.mjs";
 
 // 전체 상자
 const ProductPageContainer = styled.div`    
   display: flex;
   justify-content: center;
-  width:70%;
+  width:80%;
   max-width: 100%;
   margin: 240px auto;
 `;
 
 // 상품 정보 상자
 const ProductInfoContainer = styled.span`   
-    display: flex;
+  display: flex;
 `;
 
 // 상품 이미지
@@ -34,6 +35,10 @@ const ProductImage = styled.span`
 // 상품 이미지 제외 정보
 const ProductTextInfoContainer = styled.div`  
   margin-left: 30px;
+  display: flex;     
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
 `;
 
 // 상품 카테고리
@@ -65,9 +70,9 @@ const ProductBrand = styled.div`
   word-wrap: break-word;
 `;
 
-// 최고가
-const ProductHighPrice = styled.div`  
-  margin-top: 15px;
+// 쇼핑몰
+const ProductMallName = styled.div`  
+  margin-top: 10px;
   color: ${Colors.secondary400};
   font-size: 20px;
   font-weight: 500;
@@ -77,7 +82,17 @@ const ProductHighPrice = styled.div`
 
 // 최저가
 const ProductLowPrice = styled.div` 
-  margin-top: 15px;
+  margin-top: 10px;
+  color: ${Colors.secondary400};
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 30px;
+  word-wrap: break-word;
+`;
+
+// 상품 정보 URL
+const ProductURL = styled.div` 
+  margin-top: 10px;
   color: ${Colors.secondary400};
   font-size: 20px;
   font-weight: 500;
@@ -91,15 +106,15 @@ const ProductAddBtn = styled.button`
   align-items: center;         
   gap: 8px;    
   background-color: ${Colors.primary400};
-  width: 177px;
-  height: 50px;
+  width: 160px;
+  height: 45px;
   color: white;
   border: none;
   border-radius: 15px;
   padding: 12px 15px;
   cursor: pointer;
-  font-size: 18px;
-  margin-top: 115px;
+  font-size: 15px;
+  margin-top: auto;
   font-weight: 700;
   word-wrap: break-word;
 `;
@@ -115,19 +130,52 @@ const  ProductAddImage = styled.span`
   background-repeat: no-repeat; 
 `;
 
+// 링크 디자인
+const StyledLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+  font-size: 17px;
+
+  &:hover {
+    color: inherit;
+  }
+`;
+
 function ProductDetailPage() {
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const product = location.state?.product;
+
+  // 위시 추가 페이지로 이동
+  const handleAddWishExistClick = () => {
+    navigate("/wish/add/exist", { state: { product } });
+  };
+
+  // 상품 존재X 예외 처리
+  if (!product) return;
 
     return (
         <ProductPageContainer>
           <ProductInfoContainer>
-            <ProductImage imageUrl={ProductImageUrl}/>
+            <ProductImage imageUrl={product.image} />
             <ProductTextInfoContainer>
-              <ProductCategory>문구{">"}필기류{">"}색연필</ProductCategory>
-              <ProductName>감성 투명 아이패드 케이스 에어 7세대 6세대 11인치 5세대 4세대 10.9인치 오드밤</ProductName>
-              <ProductBrand>브랜드 | 스타벅스</ProductBrand>
-              <ProductHighPrice>최고가 | 9000원</ProductHighPrice>
-              <ProductLowPrice>최저가 | 2500원</ProductLowPrice>
-              <ProductAddBtn>
+              <ProductCategory>
+                  {[
+                    product.category1,
+                    product.category2,
+                    product.category3,
+                    product.category4
+                  ]
+                    .filter(Boolean)
+                    .join(" > ")}
+              </ProductCategory>
+              <ProductName>{product.title}</ProductName>
+              <ProductBrand>브랜드 | {product.brand}</ProductBrand>
+              <ProductMallName>쇼핑몰 | {product.mallName}</ProductMallName>
+              <ProductLowPrice>가격 | {product.lprice}원</ProductLowPrice>
+              <ProductURL>URL | <StyledLink href={product.link} target="_blank" rel="noopener noreferrer">{product.link}</StyledLink></ProductURL>
+              <ProductAddBtn onClick={handleAddWishExistClick}>
                 <ProductAddImage imageUrl={addImageURL}/>
                 위시 추가하기</ProductAddBtn>
             </ProductTextInfoContainer>

--- a/src/pages/product/ProductPage.jsx
+++ b/src/pages/product/ProductPage.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import ProductPreviewCard from "../../components/product/ProductPreviewCard";
 import SearchIcon from "../../assets/search.svg"
@@ -109,10 +110,12 @@ const LookMoreBtn = styled.button`
 
 function ProductPage() {
 
+  const navigate = useNavigate();
   const [data, setData] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1); 
   const [hasMore, setHasMore] = useState(true); 
+  const latestSearch = useRef("");
 
   // searchTerm(검색어) 바뀌면 page 1로 초기화
   useEffect(() => {
@@ -123,7 +126,9 @@ function ProductPage() {
   useEffect(() => {
     const shoppingData = async () => {
       try {
+        latestSearch.current = searchTerm;
         const result = await fetchShoppingData({ query: searchTerm || "가구", page });
+        if (latestSearch.current !== searchTerm) return;
         const newItems = result.items;
 
         if (page === 1) {
@@ -152,6 +157,11 @@ function ProductPage() {
     }
   };
 
+  // 상품 상세 보기로 이동동
+  const handleCardClick = (item) => {
+    navigate("/product-info", { state: { product: item } });
+  };
+
     return (
         <ProductPageContainer>
             <SearchContainer>
@@ -171,15 +181,11 @@ function ProductPage() {
                 </ButtonWrapper>
                 <ProductInnerContainer>
                   {data.map((item, idx) => (
-                    <ProductPreviewCard
-                      key={idx}
-                      image={item.image}
-                      title={item.title}
-                      hprice={item.hprice}
-                      lprice={item.lprice}
-                    />
+                    <div key={idx} onClick={() => handleCardClick(item)} style={{ cursor: "pointer" }}>
+                      <ProductPreviewCard item={item} />
+                    </div>
                   ))}
-               </ProductInnerContainer>
+                </ProductInnerContainer>
                        {hasMore && (
                 <LookMoreBtnWrapper>
                   <LookMoreBtn onClick={loadMore}>더 보기</LookMoreBtn>

--- a/src/pages/wish/AddWishExistPage.jsx
+++ b/src/pages/wish/AddWishExistPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import addImageURL from "../../assets/productAdd.svg";
 import lockImageURL from "../../assets/wishLockGrey.svg";
@@ -300,14 +301,30 @@ function AddWishExistPage() {
     const categories = ["식비", "카페", "쇼핑", "건강", "취미", "교통비", "기타 생활비"];
     const [isPublic, setIsPublic] = useState(false);
     const [searchTerm, setSearchTerm] = useState("");
+    const location = useLocation();
+    const product = location.state?.product;
+
+    // 상품 존재X 예외 처리
+    if (!product) {
+      return;
+    } 
 
     return (
         <ProductPageContainer>
           <ProductInfoContainer>
-            <ProductImage imageUrl={ProductImageUrl}/>
+            <ProductImage imageUrl={product.image}/>
             <ProductTextInfoContainer>
-              <ProductCategory>문구 {" > "} 필기류 {" > "} 색연필</ProductCategory>
-              <ProductName>감성 투명 아이패드 케이스 에어 7세대 6세대 11인치 5세대 4세대 10.9인치 오드밤</ProductName>
+              <ProductCategory>
+                {[
+                  product.category1,
+                  product.category2,
+                  product.category3,
+                  product.category4
+                ]
+                .filter(Boolean)
+                .join(" > ")}
+              </ProductCategory>
+              <ProductName>{product.title}</ProductName>
               <ProductInputInfoContainer>
                 <ProductCategoryContainer>
                   <ProductCategoryText>카테고리</ProductCategoryText>


### PR DESCRIPTION
#69

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #69 

## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 네이버 API 에서 받는 상품 변경
- 상품 상세 보기 페이지로 이동 연결
- 존재 상품 담기 페이지로 이동 연결
![image](https://github.com/user-attachments/assets/82d94b7b-4765-4915-bc9f-c38324659c8a)

![image](https://github.com/user-attachments/assets/f44d801c-32ff-44a8-83cd-f130d88277c8)



## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 최고가가 없는 상품이 많아서 상품 검색 페이지에서 최고가 > 브랜드, 최저가 > 가격으로 바꿨습니다
- 상품 상세 보기 페이지가 허전하고 '상세'의 의미를 갖기에는 제공 정보가 부족하다고 느껴서 쇼핑몰과 상품 정보 URL을 추가했습니다.
